### PR TITLE
Add git-url + build button

### DIFF
--- a/app/controllers/toolbox_controller.rb
+++ b/app/controllers/toolbox_controller.rb
@@ -54,5 +54,11 @@ class ToolboxController < ApplicationController
     end
   end
 
+  def build_package
+    respond_to do |format|
+      format.js
+    end
+  end
+
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
+require 'net/http'
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
   def render_changelog(changelog)
@@ -68,6 +69,34 @@ module ApplicationHelper
       entry.package = pac
       entry.save
     end
+  end
+
+  def submit_build(pac, prod)
+
+      uri = URI.parse(URI.encode(APP_CONFIG["mead_scheduler"]))
+      req = Net::HTTP::Put.new("/rest/build/sched/#{prod}/#{pac.name}")
+      mode = pac.wrapper_build == 'No' ? 'chain': 'wrapper'
+      params = {:mode => mode, :userid => pac.user.email, :sources => pac.git_url, :clentry => ''}
+      req.set_form_data(params)
+
+      res = Net::HTTP.start(uri.host, uri.port) do |http|
+        http.request(req)
+      end
+
+      case res.code
+      when "202"
+          "202: Successfully queued package #{pac.name} for building in prod: #{prod}"
+      when "400"
+          "400: Bad Request: One of the mandatory paramenters is missing or has an invalid value.\n
+          Parameters used:  #{params.to_json} \n
+          #{res.body}"
+      when "409"
+          "409: Rejected, build already scheduled for this package \n #{res.body}"
+      else
+          "#{res.code} error! \n
+          Parameters used: #{params.to_json} \n
+          #{res.body}"
+      end
   end
 
   def convert_worktime(worktime)

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -36,9 +36,18 @@ class Package < ActiveRecord::Base
   validates_presence_of :created_by
   validates_presence_of :updated_by
 
+
+  validates_format_of :git_url, :with => /git:\/\/git\.app\.eng\.bos\.redhat\.com/,
+                      :message => "does not contain git://git.app.eng.bos.redhat.com",
+                      :allow_blank => true
+  validates_format_of :git_url, :with => /.*#[\w]{5,}/,
+                      :message => "should have format <git_url>#<commit_id>, <commit_id> should be at least 5 characters long",
+                      :allow_blank => true
+
   default_value_for :time_consumed, 0
   default_value_for :time_point, 0
   default_value_for :status_changed_at, Time.now
+  default_value_for :wrapper_build, 'No'
 
   def self.per_page
     10

--- a/app/views/packages/edit.html.erb
+++ b/app/views/packages/edit.html.erb
@@ -19,6 +19,8 @@
         <%= render :partial => 'packages/fields/task', :locals => {:f => f} %>
         <%= render :partial => 'packages/fields/status', :locals => {:f => f} %>
         <%= render :partial => 'packages/fields/tags', :locals => {:f => f} %>
+        <%= render :partial => 'packages/fields/git_url', :locals => {:f => f} %>
+        <%= render :partial => 'packages/fields/wrapper_build', :locals => {:f => f} %>
         <%= render :partial => 'packages/fields/assignee', :locals => {:f => f} %>
         <%# render :partial => 'packages/fields/track_time' %>
 

--- a/app/views/packages/fields/_build.html.erb
+++ b/app/views/packages/fields/_build.html.erb
@@ -1,0 +1,18 @@
+<div style="text-align: left;">
+<% if logged_in? && @package.status.code == 'inprogress' && ! @package.git_url.blank?%>
+    <%= render :partial => 'layouts/sep_tiny' %>
+    <% form_remote_tag(
+               :url => {:controller => "toolbox", :action => "build_package"},
+               :loading => "Element.show('spinner_build_#{@package.id}');",
+               :success => "Element.hide('spinner_build_#{@package.id}');
+           ") do %>
+          <%= hidden_field_tag :package_id, @package.id %>
+          <%= render :partial => 'packages/fields/git_url_display' %>
+          <%= submit_tag 'Build' %>
+          <%= render :partial => 'layouts/progress_indicator', :locals => {:progress_indicator_id => "spinner_build_#{@package.id}"} %>
+        </div>
+    <% end %>
+<% else %>
+ <%= render :partial => 'packages/fields/git_url_display' %>
+<% end %>
+<%= render :partial => 'layouts/sep_tiny' %>

--- a/app/views/packages/fields/_git_url.html.erb
+++ b/app/views/packages/fields/_git_url.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td>
+  Git-URL
+  </td>
+  <td style="text-align:left;">
+    <%= f.text_field :git_url %>
+    <%# render :partial => 'sync', :locals => {:key => 'name'} %>
+  </td>
+</tr>

--- a/app/views/packages/fields/_git_url_display.html.erb
+++ b/app/views/packages/fields/_git_url_display.html.erb
@@ -1,0 +1,4 @@
+Git URL:
+<% unless @package.git_url.blank? %>
+    <%= h @package.git_url %>
+<% end %>

--- a/app/views/packages/fields/_wrapper_build.html.erb
+++ b/app/views/packages/fields/_wrapper_build.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td>
+    <%= f.label :wrapper_build %>
+  </td>
+  <td>
+    <%= f.check_box :wrapper_build, {}, 'Yes', 'No' %>
+  </td>
+</tr>

--- a/app/views/packages/new.html.erb
+++ b/app/views/packages/new.html.erb
@@ -15,6 +15,8 @@
         <%= render :partial => 'packages/fields/task', :locals => {:f => f} %>
         <%= render :partial => 'packages/fields/status', :locals => {:f => f} %>
         <%= render :partial => 'packages/fields/tags', :locals => {:f => f} %>
+        <%= render :partial => 'packages/fields/git_url', :locals => {:f => f} %>
+        <%= render :partial => 'packages/fields/wrapper_build', :locals => {:f => f} %>
         <%= render :partial => 'packages/fields/assignee', :locals => {:f => f} %>
         <% get_xattrs(Task.find_by_name(unescape_url(params[:task_id])), false, true) do |attr| %>
             <%= render :partial => 'packages/fields/xattrs', :locals => {:f => f, :xattr => attr} %>

--- a/app/views/packages/show.html.erb
+++ b/app/views/packages/show.html.erb
@@ -28,17 +28,24 @@ Last Modified At:
 Status:
 <% unless @package.status.blank? %>
     <span style="<%= default_style(@package.status.style) %>">&nbsp;</span>
-    <%= h @package.status.name %>    
+    <%= h @package.status.name %>
 <% end %>
 <%= render :partial => 'layouts/sep_tiny' %>
 
 
 Tags:
-<% unless @package.tags.blank? %>    
+<% unless @package.tags.blank? %>
     <% @package.tags.each do |tag| %>
         <%= tag.key %> /
     <% end %>
 <% end %>
+<%= render :partial => 'layouts/sep_tiny' %>
+
+Wrapper build:
+    <%= h @package.wrapper_build %>
+<%= render :partial => 'layouts/sep_tiny' %>
+
+<%= render :partial => 'packages/fields/build' %>
 
 <% get_xattrs(@package.task, true, false) do |attr| %>
     <%= render :partial => 'layouts/sep_tiny' %>
@@ -56,8 +63,8 @@ Tags:
 <% if can_manage? %>
     <% unless @package.deleted? %>
         | <%= link_to 'Clone', :controller => :packages, :action => :clone, :id => escape_url(@package.name), :task_id => escape_url(@package.task.name) %>
-        | <%= link_to 'Delete', @package, 
-            :confirm => "Are you sure to delete #{escape_url(@package.name)}?", 
+        | <%= link_to 'Delete', @package,
+            :confirm => "Are you sure to delete #{escape_url(@package.name)}?",
             :method => :delete %>
     <% end %>
 <% end %>

--- a/app/views/toolbox/build_package.js.rjs
+++ b/app/views/toolbox/build_package.js.rjs
@@ -1,0 +1,7 @@
+pac = Package.find(params[:package_id])
+begin
+  res = submit_build(pac, 'eap6')
+  page.alert(res);
+rescue TypeError => e
+  page.alert(e.message)
+end

--- a/config/appconfig.yml
+++ b/config/appconfig.yml
@@ -2,3 +2,5 @@ site_prefix: "http://ett.usersys.redhat.com/"
 bugzilla_prefix: "https://bugzilla.redhat.com/show_bug.cgi?id="
 bz_bug_creation_url: "http://mead.usersys.redhat.com/mead-bzbridge/bug/mock"
 bz_bug_query_url: "http://mead.usersys.redhat.com/mead-bzbridge/bug/"
+
+mead_scheduler: "http://mead.usersys.redhat.com"

--- a/db/migrate/20130704174612_add_git_url_to_packages.rb
+++ b/db/migrate/20130704174612_add_git_url_to_packages.rb
@@ -1,0 +1,9 @@
+class AddGitUrlToPackages < ActiveRecord::Migration
+  def self.up
+    add_column :packages, :git_url, :string
+  end
+
+  def self.down
+    remove_column :packages, :git_url
+  end
+end

--- a/db/migrate/20130705144037_add_wrapper_build_to_packages.rb
+++ b/db/migrate/20130705144037_add_wrapper_build_to_packages.rb
@@ -1,0 +1,9 @@
+class AddWrapperBuildToPackages < ActiveRecord::Migration
+  def self.up
+      add_column :packages, :wrapper_build, :string
+  end
+
+  def self.down
+      remove_column :packages, :wrapper_build
+  end
+end


### PR DESCRIPTION
The Build Button will only appear if Status is 'InProgress' and a git-url
is provided
- When editing or creating a new package, the git-url format will be verified
- Addition of a 'wrapper build' field to specify if build is a wrapper build or
  a chain build
- Pressing the Build button will submit a PUT to our mead-scheduler website, and
  using the return code as an indication, the appropriate message will be shown
  to the user.
- Use of AJAX for submitting builds!

TODO:
- Right now the prod is hardcoded to 'eap6'. Eventually when we will use this
  feature with eap5, we'd like to find a better solution.
  -
