### PR TITLE
Auto fill the mead and brew information when switching to the Finished Status

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -461,7 +461,7 @@ class ApplicationController < ActionController::Base
       session[:bz_pass] = pwd
     end
   end
-  
+
   def bz_bug_creation_uri
     if Rails.env.production?
       return URI.parse(APP_CONFIG['bz_bug_creation_url'])
@@ -469,5 +469,28 @@ class ApplicationController < ActionController::Base
       return URI.parse(APP_CONFIG['bz_bug_creation_url_mocked'])
     end
   end
-  
+
+   def get_mead_name(brew_pkg)
+      uri = URI.parse(URI.encode(APP_CONFIG["mead_scheduler"] +
+            "/mead-brewbridge/pkg/wrapped/#{brew_pkg}"))
+      res = Net::HTTP.get_response(uri)
+     if res.code == "200" && !res.body.include?("ERROR")
+          res.body
+      else
+          nil
+      end
+  end
+
+   def get_brew_name(pac)
+      # TODO: make the tag more robust
+      tag = pac.task.candidate_tag + '-build'
+      uri = URI.parse(URI.encode(APP_CONFIG["mead_scheduler"] +
+            "/mead-brewbridge/pkg/latest/#{tag}/#{pac.name}"))
+      res = Net::HTTP.get_response(uri)
+     if res.code == "200" && !res.body.include?("ERROR")
+          res.body
+      else
+          nil
+      end
+  end
 end

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -178,6 +178,17 @@ class PackagesController < ApplicationController
             log_entry.save
           end
 
+          xattrs = @package.task.setting.xattrs.split(',')
+
+          if @package.status.code == 'finished' &&
+             xattrs.include?('mead') &&
+             xattrs.include?('brew')
+            brew_pkg = get_brew_name(@package)
+
+            @package.brew = brew_pkg unless brew_pkg.nil?
+            @package.mead = get_mead_name(brew_pkg) unless brew_pkg.nil?
+          end
+
           @package.save
 
           Changelog.package_updated(@orig_package, @package, @orig_tags)


### PR DESCRIPTION
- Uses the mead-brewbridge to get this information
- Will not update if for any reasons the mead-brewbridge returns an error
# TODO:
- improve the determination of the tags that a package belongs to
