### PR TITLE
Change of some UI stuff

### DIFF
--- a/app/views/import/show.html.erb
+++ b/app/views/import/show.html.erb
@@ -23,9 +23,9 @@
 
       <%= render :partial => "layouts/sep" %>
       <pre>
-      * To use the auto bug creation function, you must provide the Assignee and Version for each package.
-        Here is the format: package_name,version,assignee
-        Example: hoge,1.0,weli
+      * To use the auto bug creation function, you must provide the Version for each package.
+        Here is the format: package_name,version
+        Example: hoge,1.0
 
       * NOTE: Please be patient after clicking 'Import', and don't resubmit the form! It will use a long
         time to create bugs in BZ.

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -7,6 +7,7 @@
         <%= render :partial => 'tasks/fields/name', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/candidate_tag', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/target_release', :locals => {:f => f} %>
+        <%= render :partial => 'tasks/fields/tag_version', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/description', :locals => {:f => f} %>
 		<%= render :partial => 'statuses/fields/can_show', :locals => {:f => f} %>
         <tr>

--- a/app/views/tasks/fields/_tag_version.html.erb
+++ b/app/views/tasks/fields/_tag_version.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td>
+    <%= f.label "Version" %>
+    <br/>
+  </td>
+  <td>
+    <%= f.text_field :tag_version %>
+  </td>
+</tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -7,6 +7,7 @@
       <th>Can Show</th>
       <th>Candidate Tag</th>
       <th>Target Release</th>
+      <th>Version</th>
       <% if can_manage? %>
           <th>Operation</th>
       <% end %>
@@ -28,6 +29,13 @@
                 -
             <% else %>
                 <%= task.target_release %>
+            <% end %>
+          </td>
+          <td>
+            <% if task.tag_version.blank? %>
+                -
+            <% else %>
+                <%= task.tag_version %>
             <% end %>
           </td>
           <% if can_manage? %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -7,6 +7,7 @@
         <%= render :partial => 'tasks/fields/name', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/candidate_tag', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/target_release', :locals => {:f => f} %>
+        <%= render :partial => 'tasks/fields/tag_version', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/description', :locals => {:f => f} %>
 		<%= render :partial => 'statuses/fields/can_show', :locals => {:f => f} %>
         <tr>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -28,6 +28,14 @@
     </tr>
     <tr>
       <td>
+        Version:
+      </td>
+      <td>
+        <%= h @task.tag_version %>
+      </td>
+    </tr>
+    <tr>
+      <td>
         Description:
       </td>
       <td style="text-align: left;text-wrap:normal;white-space:normal;">

--- a/db/migrate/20130715201906_add_tag_version_to_tasks.rb
+++ b/db/migrate/20130715201906_add_tag_version_to_tasks.rb
@@ -1,0 +1,9 @@
+class AddTagVersionToTasks < ActiveRecord::Migration
+  def self.up
+    add_column :tasks, :tag_version, :string
+  end
+
+  def self.down
+    remove_column :tasks, :tag_version
+  end
+end


### PR DESCRIPTION
- Remove assignee part in the 'import' area
  
  Use of 'Import' is used to create new 'Open' packages quickly and set their
  versions. The assignees are not known at this point.
- Add field for 'Version' in the Tasks.
  
  The version is needed to set the 'tagversion' parameter when we create a new
  bug in Bugzilla.
  
  The current way of doing it in the bz_bugs_controller.rb incorrectly sets the
  'tagversion' to the candidate tag.
- Set the version in the package to be the same version as specified in the
  'Import' field.
