### PR TITLE
Adding validation for bz_password and check bz credentials

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -120,6 +120,15 @@ class PackagesController < ApplicationController
     params[:package] ||= Hash.new
     params[:package][:id] = @package.id
 
+    if !params[:bzauth_user].nil?
+        if params[:bzauth_pwd].blank?
+            redirect_to params[:request_path], :notice => 'You need to enter your Bugzilla Password!'
+            return
+        elsif !verify_bz_credentials(params)
+            redirect_to params[:request_path], :notice => 'Wrong Bugzilla email or password!'
+            return
+        end
+    end
 
     if @package.created_by.blank?
       params[:package][:created_by] = current_user.id
@@ -196,7 +205,7 @@ class PackagesController < ApplicationController
 
                   if bz_bug.summary.match(/^Upgrade/)
                     #if get_assignee(bz_bug, params) == @assignee.email
-                    if bz_bug.assignee == @assignee.email
+                    if bz_bug.bz_assignee == @assignee.email
                           update_bug(bz_bug.bz_id, @assignee.email,
                                      extract_username(params[:bzauth_user]),
                                      session[:bz_pass], BzBug::BZ_STATUS[:modified], oneway='true')
@@ -593,5 +602,19 @@ class PackagesController < ApplicationController
       assignee = bz_info["assignee"]
     end
     assignee
+  end
+  def verify_bz_credentials(params)
+    url = URI.parse(APP_CONFIG["mead_scheduler"] +
+                    "/mead-bzbridge/bug/status/966279?userid="\
+                    "#{extract_username(params[:bzauth_user])}&pwd=#{params[:bzauth_pwd]}")
+    req = Net::HTTP::Get.new(url.to_s)
+    res = Net::HTTP.start(url.host, url.port) {|http|
+      http.request(req)
+    }
+    if res.code == "200"
+      return true
+    else
+      return false
+    end
   end
 end


### PR DESCRIPTION
The BZ credentials are checked by trying to fetch the info of one bug. If the
return code is 200, then credentials are valid.

IMPORTANT Bug fix in linking of bugzilla links
