### PR TITLE
Removing valiations on git-url --> they are too restrictive

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -36,14 +36,6 @@ class Package < ActiveRecord::Base
   validates_presence_of :created_by
   validates_presence_of :updated_by
 
-
-  validates_format_of :git_url, :with => /git:\/\/git\.app\.eng\.bos\.redhat\.com/,
-                      :message => "does not contain git://git.app.eng.bos.redhat.com",
-                      :allow_blank => true
-  validates_format_of :git_url, :with => /.*#[\w]{5,}/,
-                      :message => "should have format <git_url>#<commit_id>, <commit_id> should be at least 5 characters long",
-                      :allow_blank => true
-
   default_value_for :time_consumed, 0
   default_value_for :time_point, 0
   default_value_for :status_changed_at, Time.now


### PR DESCRIPTION
Some people have been using the git url field for entering an svn link. Also, some people are using a tag, instead of a commit id in their git-url.

In both cases, the validations will not like those inputs. Thus I decided to remove those validations to help in those cases.
