### PR TITLE
Fix for notification/email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -574,4 +574,19 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # mode flag needed since for mode=:create,
+  # the request_path link is wrong
+  def get_package_link(params, package, mode=:edit)
+    hardcoded_string = APP_CONFIG["site_prefix"] +
+        "tasks/" + escape_url(@package.task.name) +
+        "/packages/" + escape_url(@package.name)
+
+    if mode == :create
+      hardcoded_string
+    elsif params[:request_path].blank?
+      hardcoded_string
+    else
+      params[:request_path]
+    end
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,11 +20,12 @@ class CommentsController < ApplicationController
       if Rails.env.production?
         if Setting.activated?(@package.task, Setting::ACTIONS[:commented])
           debugger
-          Notify::Comment.create(current_user, params[:request_path], @package, @comment, Setting.all_recipients_of_package(@package, @comment.user, :comment))
+
+          Notify::Comment.create(current_user, get_package_link(params, @package), @package, @comment, Setting.all_recipients_of_package(@package, @comment.user, :comment))
         end
 
         unless params[:div_comment_notification_area].blank?
-          Notify::Comment.create(current_user, params[:request_path], @package, @comment, params[:div_comment_notification_area])
+          Notify::Comment.create(current_user, get_package_link(params, @package), @package, @comment, params[:div_comment_notification_area])
         end
       end
     end


### PR DESCRIPTION
- Email sent from ETT did not contain information about what was changed. This
  was caused because we use @package.latest_changes method to obtain what
  changed in the package. Unfortunately, we write to the @package object and
  this alters the latest_changes method output (we write to
  @package.status_changed_at, and therefore latest_changes will return that as
  the latest change instead of status_id, or assignee change, or name change).
- We fix it by calling latest_changes before @package.status_changed_at is
  written to.
- Also some minor refactorings as to how the link in the email is generated.
