### PR TITLE
Make mead information get synced synchronously

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -204,7 +204,14 @@ class PackagesController < ApplicationController
                 end
               elsif new_status.code == Status::CODES[:finished] && !@assignee.blank?
                 if has_mead_integration?(@package.task)
-                  @package.mead_action = Package::MEAD_ACTIONS[:needsync]
+                  # Disable asynchronous update <- we need that data for
+                  # bugzilla immediately
+                  # @package.mead_action = Package::MEAD_ACTIONS[:needsync]
+
+                  brew_pkg = get_brew_name(@package)
+                  @package.brew = brew_pkg unless brew_pkg.nil?
+                  @package.mead = get_mead_name(brew_pkg) unless brew_pkg.nil?
+                  @package.save
                 end
 
 


### PR DESCRIPTION
Even though getting mead info asynchronously worked fine, it kinda broke the
bugzilla comment that we post when the state is switched to 'Finished', the
mead and brew info might be outdated.
