### PR TITLE
Minor fix to csv generation

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -420,7 +420,7 @@ class PackagesController < ApplicationController
           val << package.assignee.email
         end
 
-        val << package.version
+        val << package.ver
         val << package.bz_bugs.map {|bz| bz = bz.bz_id }.join(" ")
         val << package.git_url
         val << package.mead


### PR DESCRIPTION
- package.ver, not package.version (why do we have both?)
