### PR TITLE
Fix bug in method: empty list is a 'true' in an if condition

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -179,7 +179,7 @@ class Package < ActiveRecord::Base
   end
 
   def in_shipped_list?
-    open('/var/www/html/shipped-list') { |f| f.grep("#{name}\n")  }
+    !open('/var/www/html/shipped-list') { |f| f.grep("#{name}\n")  }.empty?
   end
 
   def brew_and_is_in_errata?


### PR DESCRIPTION
Stupid bug that I introduced when refactoring.

an empty list [] in ruby still means 'true' in an if condition.

It's not the same as python, silly!
