### PR TITLE
Modify the checks to see if bz summary contain 'Upgrade'

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -223,7 +223,7 @@ class PackagesController < ApplicationController
           if Rails.env.production?
             if old_assignee_email != assignee_email
               @package.bz_bugs.each do |bz_bug|
-                if bz_bug.summary.match(/^Upgrade/) && !assignee_email.nil? && (!bz_bug.component.blank? && bz_bug.component.include?("RPMs")) && (bz_bug.keywords.include? "Rebase")
+                if bz_bug.summary.match(/Upgrade/) && !assignee_email.nil? && (!bz_bug.component.blank? && bz_bug.component.include?("RPMs")) && (bz_bug.keywords.include? "Rebase")
 
                   params_bz = {:assignee => assignee_email, :userid => shared_bzauth_user, :pwd => shared_bzauth_pass, :status => BzBug::BZ_STATUS[:assigned]}
                   update_bug(bz_bug.bz_id, oneway='true', params_bz)
@@ -258,7 +258,7 @@ class PackagesController < ApplicationController
                 # the bug statuses are waiting to be updated according to https://docspace.corp.redhat.com/docs/DOC-148169
                 if Rails.env.production? # TODO we need to write some unit tests to test all the integrations with SOA
                   @package.bz_bugs.each do |bz_bug|
-                    if bz_bug.summary.match(/^Upgrade/) && bz_bug.bz_assignee == assignee_email
+                    if bz_bug.summary.match(/Upgrade/) && bz_bug.bz_assignee == assignee_email
                       params_bz = {:assignee => assignee_email, :userid => shared_bzauth_user,
                                    :pwd => shared_bzauth_pass, :status => BzBug::BZ_STATUS[:assigned]}
 
@@ -280,7 +280,7 @@ class PackagesController < ApplicationController
 
                 if Rails.env.production?
                   @package.bz_bugs.each do |bz_bug|
-                    if bz_bug.summary.match(/^Upgrade/) && bz_bug.bz_assignee == assignee_email
+                    if bz_bug.summary.match(/Upgrade/) && bz_bug.bz_assignee == assignee_email
 
                       comment = "Source URL: #{@package.git_url}\n" +
                           "Mead-Build: #{@package.mead}\n" +

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -156,7 +156,7 @@ class Package < ActiveRecord::Base
     bz_bugs.each do |bug|
 
       if (bug.bz_status == "MODIFIED") &&
-         (bug.summary.start_with? "Upgrade") &&
+         (bug.summary.include? "Upgrade") &&
          (bug.component.include? "RPMs") &&
          (bug.keywords.include? "Rebase")
         errata_bz.push bug.bz_id


### PR DESCRIPTION
Before check was to see if bz summary starts with 'Upgrade',
now it only check if bz summary has 'Upgrade' in it.

Reason is because the way summary is now created:

'RHEL6 RPMs: Upgrade <package> to <version>' instead of
'Upgrade <package> to <version>'
