### PR TITLE
Flag brew nvrs which are out of date compared to latest in brewweb.

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -431,6 +431,19 @@ class PackagesController < ApplicationController
     end
   end
 
+  def get_latest_pkgs_from_brew
+    unless params[:secret_key] == 'birdistheword'
+      render :status => :unauthorized, :text => 'Wrong secret key' and return
+    end
+    @packages = get_packages(unescape_url(params[:task_id]), nil, nil, nil)
+    @packages.each do |package|
+      package.latest_brew_nvr = get_brew_name(package)
+      package.save
+    end
+    render :text => params[:task_id]
+
+  end
+
   def export_to_csv
 
     require 'faster_csv'

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -216,6 +216,16 @@ class Package < ActiveRecord::Base
     end
   end
 
+  def brew_style
+    if brew.nil? || brew.empty? || latest_brew_nvr.nil? || latest_brew_nvr.empty?
+      return ''
+    elsif brew == latest_brew_nvr
+      return ''
+    else
+        return "background-color: yellow;"
+    end
+  end
+
   def version_style
 
     if ver.nil? || ver.empty?

--- a/app/views/packages/index/_brew.html.erb
+++ b/app/views/packages/index/_brew.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'packages/index/field_template', :locals => {:package => package, :field_name => 'brew', :field_type => 'packages/index/field_input', :partial => 'packages/index/brew_col'} %>
+<%= render :partial => 'packages/index/field_template', :locals => {:package => package, :field_name => 'brew', :field_type => 'packages/index/field_input', :partial => 'packages/index/brew_col', :style => package.brew_style} %>

--- a/db/migrate/20131017154650_add_latest_brew_nvr_to_package.rb
+++ b/db/migrate/20131017154650_add_latest_brew_nvr_to_package.rb
@@ -1,0 +1,9 @@
+class AddLatestBrewNvrToPackage < ActiveRecord::Migration
+  def self.up
+    add_column :packages, :latest_brew_nvr, :string
+  end
+
+  def self.down
+    remove_column :packages, :latest_brew_nvr
+  end
+end


### PR DESCRIPTION
For this to work, we need to add a cronjob that will do a GET to:

http://localhost:3000/packages/get_latest_pkgs_from_brew/-1?task_id=jb-eap-6-dot-2-dot-0&secret_key=birdistheword

Flagging will be done by highlighting the brew field yellow.

The huge disadvantage is that this process takes a lot of time and will block
any other requests made while the request above is serviced.
