### PR TITLE
Temporary work-around to errata nvrs getting out of sync

### DIFF
--- a/app/controllers/errata_check_controller.rb
+++ b/app/controllers/errata_check_controller.rb
@@ -3,14 +3,22 @@ class ErrataCheckController < ApplicationController
 
   def sync
     nvrs = JSON.parse(params["nvrs"])
+
+    # advisory = params['advisory']
+
     render :text => "OK", :status => 202
 
+    # TODO: work-around for now
+    # TODO: should depend on the advisory number in the future
+    task = Task.first(:conditions => ["name = ?", 'jb-eap-6.2.0'])
+
     nvrs.each do |nvr|
-        package = Package.first(:conditions => ["brew = ?", nvr])
-        if package:
-          package.in_errata = nvr
-          package.save
-        end
+      pac_name = nvr.gsub(/-[0-9].*/, '')
+      package = Package.first(:conditions => ["task_id = ? and name = ?", task.id, pac_name])
+      if package
+        package.in_errata = nvr
+        package.save
+      end
     end
   end
 
@@ -28,9 +36,18 @@ class ErrataCheckController < ApplicationController
   end
 
   def sync_rpmdiffs
+
     rpmdiffs = JSON.parse(params['rpmdiffs'])
+
+    # TODO: work-around for now
+    # TODO: should depend on the advisory number in the future
+    task = Task.first(:conditions => ["name = ?", 'jb-eap-6.2.0'])
+
     rpmdiffs.each do |rpmdiff|
-        package = Package.first(:conditions => ["brew = ?", rpmdiff['nvr']])
+        nvr = rpmdiff['nvr']
+        pac_name = nvr.gsub(/-[0-9].*/, '')
+        package = Package.first(:conditions => ["task_id = ? and name = ?", task.id, pac_name])
+
         if package
           package.rpmdiff_status = rpmdiff['status']
           package.rpmdiff_id = rpmdiff['id']


### PR DESCRIPTION
The task is hard-coded right now. Eventually, the cron script should send the advisory number back to ETT.
