### PR TITLE
SCM URL checks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 # Filters added to this controller apply to all controllers in the application.
 # Likewise, all the methods added will be available for all controllers.
+require "xmlrpc/client"
+XMLRPC::Config::ENABLE_NIL_PARSER = true
 class ApplicationController < ActionController::Base
+
   helper :all # include all helpers, all the time
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
   helper_method :escape_url, :unescape_url, :can_manage?, :logged_in?, :has_task?, :count_packages, :can_edit_package?, :current_user, :get_task, :has_status?, :has_tag?, :deleted_style, :can_delete_comment?, :generate_request_path, :is_global?, :current_user_email, :task_has_tags?, :get_xattrs, :background_style, :confirmed?, :default_style
@@ -512,6 +515,20 @@ class ApplicationController < ActionController::Base
     puts res.response
   end
 
+
+  def get_scm_url_brew(pac)
+    server = XMLRPC::Client.new('brewhub.devel.redhat.com', '/brewhub', 80)
+    begin
+      param = server.call('getBuild', pac.mead)
+      if not param.nil?:
+        server.call('getTaskRequest', param['task_id'])[0]
+      else
+        nil
+      end
+    rescue XMLRPC::FaultException => e
+      nil
+    end
+  end
 
   def get_brew_name(pac)
     # TODO: make the tag more robust

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -275,6 +275,7 @@ class PackagesController < ApplicationController
                     # bugzilla immediately
                     # @package.mead_action = Package::MEAD_ACTIONS[:needsync]
                     get_mead_info(@package)
+                    update_source_url_info(@package)
                   end
                 end
 
@@ -547,6 +548,15 @@ class PackagesController < ApplicationController
   end
 
   protected
+
+  def update_source_url_info(package)
+    package.brew_scm_url = get_scm_url_brew(package)
+
+    if package.git_url.nil? || package.git_url.empty?
+      package.git_url = package.brew_scm_url
+    end
+    package.save
+  end
 
   def get_mead_info(package)
     brew_pkg = get_brew_name(package)

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -218,11 +218,21 @@ class Package < ActiveRecord::Base
 
   def brew_style
     if brew.nil? || brew.empty? || latest_brew_nvr.nil? || latest_brew_nvr.empty?
-      return ''
+      ''
     elsif brew == latest_brew_nvr
-      return ''
+      ''
     else
-        return "background-color: yellow;"
+      "background-color: yellow;"
+    end
+  end
+
+  def get_scm_url_style
+    if git_url.nil? || git_url.empty? || brew_scm_url.nil? || brew_scm_url.empty?
+      ''
+    elsif git_url != brew_scm_url && !can_edit_version?
+      "background-color: yellow;"
+    else
+      ''
     end
   end
 

--- a/app/views/packages/fields/_git_url.html.erb
+++ b/app/views/packages/fields/_git_url.html.erb
@@ -3,7 +3,7 @@
   Git-URL
   </td>
   <td style="text-align:left;">
-    <%= f.text_field :git_url %>
+    <%= f.text_field :git_url, :disabled => (@package.can_edit_version? == true ? nil : 'disabled')%>
     <%# render :partial => 'sync', :locals => {:key => 'name'} %>
   </td>
 </tr>

--- a/app/views/packages/index/_git_url.html.erb
+++ b/app/views/packages/index/_git_url.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'packages/index/field_template', :locals => {:package => package, :field_name => 'git_url', :field_type => 'packages/index/field_input', :partial => 'packages/index/git_url_col'} %>
+<%= render :partial => 'packages/index/field_template', :locals => {:package => package, :field_name => 'git_url', :field_type => 'packages/index/field_input', :partial => 'packages/index/git_url_col', :style => package.get_scm_url_style} %>

--- a/db/migrate/20131017223847_add_brew_scm_url_to_packages.rb
+++ b/db/migrate/20131017223847_add_brew_scm_url_to_packages.rb
@@ -1,0 +1,9 @@
+class AddBrewScmUrlToPackages < ActiveRecord::Migration
+  def self.up
+    add_column :packages, :brew_scm_url, :string
+  end
+
+  def self.down
+    remove_column :packages, :brew_scm_url
+  end
+end


### PR DESCRIPTION
- If git_url is unfilled when package is flipped to finished, then
  autofill that data
- If it is not filled, then check if the mead build scm_url is the same as the
  one in ETT
- Disable editing the git_url if the package is flipped to finished state
