### PR TITLE
Add advisory field to Tasks and other stuff

### DIFF
--- a/app/controllers/errata_check_controller.rb
+++ b/app/controllers/errata_check_controller.rb
@@ -8,9 +8,7 @@ class ErrataCheckController < ApplicationController
 
     render :text => "OK", :status => 202
 
-    # TODO: work-around for now
-    # TODO: should depend on the advisory number in the future
-    task = Task.first(:conditions => ["name = ?", 'jb-eap-6.2.0'])
+    task = Task.first(:conditions => ["advisory = ?", params[:advisory]])
 
     nvrs.each do |nvr|
       pac_name = nvr.gsub(/-[0-9].*/, '')
@@ -39,9 +37,7 @@ class ErrataCheckController < ApplicationController
 
     rpmdiffs = JSON.parse(params['rpmdiffs'])
 
-    # TODO: work-around for now
-    # TODO: should depend on the advisory number in the future
-    task = Task.first(:conditions => ["name = ?", 'jb-eap-6.2.0'])
+    task = Task.first(:conditions => ["advisory = ?", params[:advisory]])
 
     rpmdiffs.each do |rpmdiff|
         nvr = rpmdiff['nvr']

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -10,6 +10,7 @@
         <%= render :partial => 'tasks/fields/milestone', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/tag_version', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/description', :locals => {:f => f} %>
+        <%= render :partial => 'tasks/fields/advisory', :locals => {:f => f} %>
 		<%= render :partial => 'statuses/fields/can_show', :locals => {:f => f} %>
         <tr>
           <td colspan='2'>

--- a/app/views/tasks/fields/_advisory.html.erb
+++ b/app/views/tasks/fields/_advisory.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td>
+    <%= f.label :advisory %>
+    <br/>
+  </td>
+  <td>
+    <%= f.text_field :advisory %>
+  </td>
+</tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -9,6 +9,7 @@
       <th>Target Release</th>
       <th>Milestone</th>
       <th>Version</th>
+      <th>Advisory</th>
       <% if can_manage? %>
           <th>Operation</th>
       <% end %>
@@ -44,6 +45,13 @@
                 -
             <% else %>
                 <%= task.tag_version %>
+            <% end %>
+          </td>
+          <td>
+            <% if task.advisory.blank? %>
+                -
+            <% else %>
+                <%= task.advisory %>
             <% end %>
           </td>
           <% if can_manage? %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -10,6 +10,7 @@
         <%= render :partial => 'tasks/fields/milestone', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/tag_version', :locals => {:f => f} %>
         <%= render :partial => 'tasks/fields/description', :locals => {:f => f} %>
+        <%= render :partial => 'tasks/fields/advisory', :locals => {:f => f} %>
 		<%= render :partial => 'statuses/fields/can_show', :locals => {:f => f} %>
         <tr>
           <td colspan='2'>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -50,6 +50,14 @@
         <%= @task.description %>
       </td>
     </tr>
+    <tr>
+      <td>
+        Advisory:
+      </td>
+      <td style="text-align: left;text-wrap:normal;white-space:normal;">
+        <%= @task.advisory %>
+      </td>
+    </tr>
 	<tr>
       <td>Can Show</td>
       <td><%= @task.can_show %></td>

--- a/db/migrate/20131018185920_add_advisory_to_tasks.rb
+++ b/db/migrate/20131018185920_add_advisory_to_tasks.rb
@@ -1,0 +1,9 @@
+class AddAdvisoryToTasks < ActiveRecord::Migration
+  def self.up
+    add_column :tasks, :advisory, :string
+  end
+
+  def self.down
+    remove_column :tasks, :advisory
+  end
+end


### PR DESCRIPTION
Other stuff:
- Since cron job now sends the advisory to ETT, we don't have to hard-code to
  which task the packages arriving to ETT belong to. From the advisory, we'll
  try to find the task that has that advisory
