### PR TITLE
Permanent fix for source url in ETT

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -656,4 +656,14 @@ class ApplicationController < ActionController::Base
       params[:request_path]
     end
   end
+
+  def build_type(package)
+    Net::HTTP.get('mead.usersys.redhat.com', "/mead-scheduler/rest/package/eap6/#{package}/type")
+  end
+
+  def repolib_wrapper_or_rpm?(package)
+    build = build_type(package)
+    return (build == 'REPOLIB_WRAPPER') || (build == "NON_WRAPPER")
+  end
+
 end

--- a/app/controllers/toolbox_controller.rb
+++ b/app/controllers/toolbox_controller.rb
@@ -73,10 +73,8 @@ class ToolboxController < ApplicationController
 
     pac = Package.find(@package_id)
     @error = nil
-    unless !pac.status.blank? && pac.status.code == 'inprogress' &&
-           !pac.user.nil?
-          # temp hack
-           # !pac.git_url.blank? &&
+    if pac.status.blank? || pac.status.code != 'inprogress' ||
+       pac.user.nil? || (pac.git_url.blank? && !repolib_wrapper_or_rpm?(pac.name))
       @error = "You can only use the Build Button when the Git-Url is provided," \
                " the status is 'InProgress' and there is an assignee to this package"
     end


### PR DESCRIPTION
ETT will now check if the package is a repolib wrapper or rpm.
If it is, then it is going to relax its constraint on the need
for the source git url when using the 'Build button' feature.
