### PR TITLE
Special warning message when trying to build repolib packages

### DIFF
--- a/app/views/toolbox/build_package.js.rjs
+++ b/app/views/toolbox/build_package.js.rjs
@@ -1,11 +1,30 @@
 pac = Package.find(params[:package_id])
+
+
 begin
-  mode = 'chain'
-  mode = 'wrapper' if params.include? :wrapper_build
-  res = submit_build(pac, params[:clentry][:text], 'eap6', mode)
-  page.alert(res);
-  if res.start_with?('202')
-    page << "TINY.box.hide()"
+  if pac.name.include?('-eap6') && !params.include?(:wrapper_build)
+    source_pkg = pac.name.sub('-eap6', '')
+    warning_string = "This will also build the source '#{source_pkg}' package. " \
+                     "If you only want to build the '#{pac.name}' wrapper of it " \
+                     "please select CANCEL and make sure you check the Wrapper " \
+                     "only option before requesting again"
+    page << "var r = confirm(\"#{warning_string}\");"
+    page << "if (r == true) {"
+      mode = 'chain'
+      res = submit_build(pac, params[:clentry][:text], 'eap6', mode)
+      page.alert(res);
+      if res.start_with?('202')
+        page << "TINY.box.hide()"
+      end
+    page << "}"
+  else
+    mode = 'chain'
+    mode = 'wrapper' if params.include? :wrapper_build
+    res = submit_build(pac, params[:clentry][:text], 'eap6', mode)
+    page.alert(res);
+    if res.start_with?('202')
+      page << "TINY.box.hide()"
+    end
   end
 rescue TypeError => e
   page.alert(e.message)


### PR DESCRIPTION
When building repolib packages, warn the user that she will also build the
source package unless she checks the 'wrapper build only' checkbox, in which
case a wrapper build will be scheduled.
