### PR TITLE
Cleanup ett a little bit

### DIFF
--- a/app/helpers/actions_helper.rb
+++ b/app/helpers/actions_helper.rb
@@ -1,2 +1,0 @@
-module ActionsHelper
-end

--- a/app/helpers/allowed_statuses_helper.rb
+++ b/app/helpers/allowed_statuses_helper.rb
@@ -1,2 +1,0 @@
-module AllowedStatusesHelper
-end

--- a/app/helpers/bz_bugs_helper.rb
+++ b/app/helpers/bz_bugs_helper.rb
@@ -1,2 +1,0 @@
-module BzBugsHelper
-end

--- a/app/helpers/changelogs_helper.rb
+++ b/app/helpers/changelogs_helper.rb
@@ -1,2 +1,0 @@
-module ChangelogsHelper
-end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,2 +1,0 @@
-module CommentsHelper
-end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -1,2 +1,0 @@
-module ComponentsHelper
-end

--- a/app/helpers/errata_check_helper.rb
+++ b/app/helpers/errata_check_helper.rb
@@ -1,2 +1,0 @@
-module ErrataCheckHelper
-end

--- a/app/helpers/manual_log_entries_helper.rb
+++ b/app/helpers/manual_log_entries_helper.rb
@@ -1,2 +1,0 @@
-module ManualLogEntriesHelper
-end

--- a/app/helpers/p_attachments_helper.rb
+++ b/app/helpers/p_attachments_helper.rb
@@ -1,2 +1,0 @@
-module PAttachmentsHelper
-end

--- a/app/helpers/package_relationships_helper.rb
+++ b/app/helpers/package_relationships_helper.rb
@@ -1,2 +1,0 @@
-module PackageRelationshipsHelper
-end

--- a/app/helpers/packages_helper.rb
+++ b/app/helpers/packages_helper.rb
@@ -1,2 +1,0 @@
-module PackagesHelper
-end

--- a/app/helpers/readonly_tasks_helper.rb
+++ b/app/helpers/readonly_tasks_helper.rb
@@ -1,2 +1,0 @@
-module ReadonlyTasksHelper
-end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,2 +1,0 @@
-module RelationshipsHelper
-end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,2 +1,0 @@
-module SearchHelper
-end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,2 +1,0 @@
-module SessionsHelper
-end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,2 +1,0 @@
-module SettingsHelper
-end

--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -1,2 +1,0 @@
-module StatusesHelper
-end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,2 +1,0 @@
-module TagsHelper
-end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,3 +1,0 @@
-module TasksHelper
-  
-end

--- a/app/helpers/toolbox_helper.rb
+++ b/app/helpers/toolbox_helper.rb
@@ -1,2 +1,0 @@
-module ToolboxHelper
-end

--- a/app/helpers/user_views_helper.rb
+++ b/app/helpers/user_views_helper.rb
@@ -1,2 +1,0 @@
-module UserViewsHelper
-end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,0 @@
-module UsersHelper
-end

--- a/app/helpers/workflows_helper.rb
+++ b/app/helpers/workflows_helper.rb
@@ -1,2 +1,0 @@
-module WorkflowsHelper
-end

--- a/app/helpers/workload_helper.rb
+++ b/app/helpers/workload_helper.rb
@@ -1,2 +1,0 @@
-module WorkloadHelper
-end


### PR DESCRIPTION
As ETT (and in the future, Wildbee) grows, we need to better manage the existing
code. My first attempt to cleanup ETT a little bit is by deleting the unused
helper functions that get autogenerated by Ruby on Rails, in the hopes that it
will create less confusion when people will look at the application. Why?
Because those helpers look like dead code to me and dead code leads to confusion
("Is it in use or not?")

My goal was inspired from this [blog](http://railspikes.com/2008/8/22/how-to-fix-your-rails-helpers) post.

In the future, I'd like to add more unit tests and maybe also try to move code
into their rightful place. I've been guilty of putting code in the wrong areas
while I was learning Rails and I'd like to fix my mistakes.

As such, I've learned that helpers are meant to be really helpers for views and
nothing else. I'll therefore move the stuff in application_helper.rb to their
rightful place in a future commit.

My ultimate goal is to make the codebase easier to read, and maintain when ETT
will become legacy and replaced by its replacement, Wildbee.

Wildbee itself is not as future complete as ETT but given some time, it should
be, thanks to the efforts of Francisco and Miles.
