### PR TITLE
ReadOnly task: don't touch pkgs of different prods

### DIFF
--- a/app/models/readonly_task.rb
+++ b/app/models/readonly_task.rb
@@ -21,6 +21,10 @@ class ReadonlyTask < ActiveRecord::Base
             if pkg.nvr_in_brew(main_distro) != pkg_to_change.nvr_in_brew(main_distro)
               next
             end
+            # only remove packages from their erratas if they are in the same prod
+            if pkg.task.prod != pkg_to_change.task.prod
+              next
+            end
             pkg_to_change.status_id = status.id
             str += pkg_to_change.remove_nvr_and_bugs_from_errata.to_s
             str += "\n"


### PR DESCRIPTION
When a task is put on readonly, similar packages in different tasks will
get their nvrs, bugs removed from their respective erratas.

This behaviour is generally ok, but only if we touch the similar
packages being in the same prod as the origin task marked as readonly.
Otherwise we shouldn't do it.