### PR TITLE
We should be using candidate-tag, not target tag

### DIFF
--- a/app/controllers/cronjob_modes_controller.rb
+++ b/app/controllers/cronjob_modes_controller.rb
@@ -94,8 +94,8 @@ class CronjobModesController < ApplicationController
         distros << tag.os_arch
         to_add[tag.os_arch] = tag.modes_to_build
 
-        unless tag.target_tag.blank? || tag.errata_prod_release.blank?
-          to_add[:errata][tag.target_tag] = tag.errata_prod_release
+        unless tag.candidate_tag.blank? || tag.errata_prod_release.blank?
+          to_add[:errata][tag.candidate_tag + "-candidate"] = tag.errata_prod_release
         end
 
         branch = tag.candidate_tag if count == 0

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -962,7 +962,7 @@ class Package < ActiveRecord::Base
         link += '&erratum=' + self.errata
       end
 
-      link += '&tag=' + os_tag.target_tag unless os_tag.target_tag.blank?
+      link += '&tag=' + os_tag.candidate_tag + "-candidate" unless os_tag.candidate_tag.blank?
       links << [link, latest_brew_nvr, advisory_used]
     end
     links


### PR DESCRIPTION
We should be using candidate tag and not target tag for
products_to_build. The mead scheduler will only provide the candidate
tag when it'll want stuff to be added to errata.