### PR TITLE
[ETT-91] Fix PR stuff in ETT

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -95,10 +95,16 @@ class Package < ActiveRecord::Base
 
   def close_github_pr_closed(github_client)
 
-    git_repo = ENV['GITHUB_REPO_LINK']
+    # github_pr is a github url
+    # https://github.com/kaka/koukou/pull/482
+    # we need to extract the git repo name and url from it.
+    # pr_number = '482'
+    pr_number = self.github_pr.split('/')[-1]
 
+    # git_repo = 'kaka/koukou'
+    git_repo = self.github_pr.sub("https://github.com/", "").sub(/\/pull.*/, '')
     begin
-      pull_request = github_client.pull_request git_repo, self.github_pr
+      pull_request = github_client.pull_request git_repo, pr_number
 
       if pull_request.state == 'closed'
         # TODO: yeah maybe one day rename that to something more appropriate
@@ -178,7 +184,7 @@ class Package < ActiveRecord::Base
     if self.github_pr.blank?
       ""
     else
-      "https://github.com/#{ENV["GITHUB_REPO_LINK"]}/pull/#{self.github_pr}"
+      "#{self.github_pr}"
     end
   end
 

--- a/app/views/packages/fields/_github_pr.html.erb
+++ b/app/views/packages/fields/_github_pr.html.erb
@@ -3,7 +3,7 @@
       Github PR
   </td>
   <td style="text-align:left;">
-    <%= f.text_field :github_pr %>
+    <%= f.text_field :github_pr, :placeholder => 'e.g https://github.com/project/name/pull/3' %>
     <%# render :partial => 'sync', :locals => {:key => 'name'} %>
   </td>
 </tr>

--- a/db/migrate/20160529200043_modify_pr_field_for_packages.rb
+++ b/db/migrate/20160529200043_modify_pr_field_for_packages.rb
@@ -1,0 +1,9 @@
+class ModifyPrFieldForPackages < ActiveRecord::Migration
+  def self.up
+    change_column :packages, :github_pr, :string
+  end
+
+  def self.down
+    change_column :packages, :github_pr, :integer
+  end
+end


### PR DESCRIPTION
Instead of having Github PR number, now specify the whole URL.

Reasoning:
- Different projects don't use the same github repository anymore.

Changes done/to do:
- force migration of model package for field github_pr: from integer to
  string
- modify the github pr field to show full url
- change the backend code
- change the frontend code