### PR TITLE
[ETT-123] task id not filled for osbs build

### DIFF
--- a/app/models/brew_service.rb
+++ b/app/models/brew_service.rb
@@ -10,16 +10,11 @@ class BrewService
 	############################################################################
 	class << self
 	  def get_brew_rpm_link(nvr, retries = 3)
-      get_brew_item('getBuild', nvr, 'task_id', taskinfo_link)
+      get_brew_item('getBuild', nvr, 'build_id', buildinfo_link)
 	  end
 
     def get_brew_maven_link(nvr)
-      result = get_brew_item('getMavenBuild', nvr, 'build_id', buildinfo_link)
-      if result.nil?
-        get_brew_rpm_link(nvr)
-      else
-        result
-      end
+      get_brew_rpm_link(nvr)
     end
 
     def get_scm_url_brew(mead_nvr)


### PR DESCRIPTION
I don't recall anymore why I was using task_id to generate the link, it
looks like I can instead use the build_id to do so, with the advantage
that it works for both Mead and Brew builds.