### PR TITLE
Ability to activate advisory when task unfrozen

### DIFF
--- a/app/models/mead_scheduler_service.rb
+++ b/app/models/mead_scheduler_service.rb
@@ -99,6 +99,17 @@ class MeadSchedulerService
       end
     end
 
+    def set_advisory_status(advisory, active_status)
+      req = Net::HTTP::Put.new("/mead-scheduler/rest/errata/#{advisory}?active=#{active_status}")
+      uri = URI.parse(URI.encode(APP_CONFIG["mead_scheduler"]))
+
+      res = Net::HTTP.start(uri.host, uri.port) do |http|
+        http.request(req)
+      end
+
+      res
+    end
+
     def maintainer(prod, pac_name)
       ans = ''
       begin


### PR DESCRIPTION
If a task is frozen, ETT will tell the Mead scheduler endpoint to mark
the advisories in that task as inactive.

And if a task is unfrozen, ETT wil ltell the Mead scheduler endpoint to
mark the advisories in that task as active.